### PR TITLE
[vscode] use default path when default path is not empty

### DIFF
--- a/src/mlirContext.ts
+++ b/src/mlirContext.ts
@@ -331,10 +331,9 @@ export class MLIRContext implements vscode.Disposable {
 
     // If a path hasn't been set, try to use the default path.
     if (filePath === '') {
-      if (defaultPath === '') {
-        return filePath;
+      if (defaultPath !== '') {
+        return defaultPath;
       }
-      filePath = defaultPath;
 
       // Fallthrough to try resolving the default path.
     }


### PR DESCRIPTION
use default path of `$PATH`
